### PR TITLE
Preliminary Gitlab scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # repo-scraper [![Build Status](https://travis-ci.org/gaggle/repo-scraper.svg?branch=master)](https://travis-ci.org/gaggle/repo-scraper) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-Scrape GitHub repository data, to be consumed by [repo-lister][repo-lister].
+Scrape repository data, to be consumed by [repo-lister][repo-lister].
 
-In principle the scraper supports multiple repository providers, but only GitHub is supported at the moment. Let me know if you'd like others. There's a [WIP PR to test GitLab integration][gl-pr] if that's interesting?
+Multiple repository providers can be supported, currently we can scrape from GitHub and GitLab.
 
 
 ## Development
@@ -16,4 +16,3 @@ npm test && npm version patch && (export VERSION=`node -p "require('./package.js
 
 
 [repo-lister]: https://github.com/gaggle/repo-lister
-[gl-pr]: https://github.com/gaggle/repo-scraper/pull/1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-scraper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-scraper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "lib/index.js",
   "bin": {
     "repo-scrape": "bin/cli.js"

--- a/recipes/gitlab.js
+++ b/recipes/gitlab.js
@@ -1,0 +1,65 @@
+const url = require('url')
+const urljoin = require('url-join')
+
+const errors = require('../lib/errors')
+const { log } = require('../lib/log')
+
+const DEFAULT_GL_URL = 'https://gitlab.com'
+
+exports.initialize = async () => {
+  log.warn('Gitlab scraping is WIP, please reach out as this project needs users to test the functionality')
+  if (!process.env.GL_TOKEN) { throw new errors.InitializeError('Must specify GL_TOKEN environment variable') }
+}
+
+exports.scrape = async container => {
+  const textRequest = async (...args) => {
+    const buffer = await container.safeRequest(...args)
+    return buffer.toString()
+  }
+
+  const apiBase = process.env.GL_URL || DEFAULT_GL_URL
+  const headers = {
+    Accept: 'application/json',
+    'Private-Token': process.env.GL_TOKEN
+  }
+
+  let projects = JSON.parse(await textRequest('gl_projects', {
+    url: url.parse(urljoin(apiBase, 'api/v4/projects?owned=true')), headers
+  }))
+
+  /**
+   * It's useful during dev to limit the repos being processed,
+   * so lets do a quick regex filtering via env. variable
+   */
+  if (process.env.DEBUG_FILTER_REPO) {
+    projects = projects.filter(el => RegExp(process.env.DEBUG_FILTER_REPO).test(el.path_with_namespace))
+  }
+
+  await Promise.all(await projects.map(async el => {
+    let languages = JSON.parse(await textRequest(`gl_languages/${el.path_with_namespace}`, {
+      url: `${el._links.self}/languages`, headers
+    }))
+
+    let mergeRequests = JSON.parse(await textRequest(`gl_merge_request/${el.path_with_namespace}`, {
+      url: el._links.merge_requests, headers
+    }))
+
+    await container.setRepoData(el.path_with_namespace, {
+      badges: [],
+      description: el.description,
+      fullName: el.name_with_namespace,
+      id: el.path_with_namespace,
+      language: Object.keys(languages)[0],
+      openIssues: el.open_issues_count,
+      openIssuesHtmlUrl: `${el.web_url}/issues`,
+      openPullrequests: mergeRequests.length,
+      openPullrequestsHtmlUrl: `${el.web_url}/merge_requests`,
+      ownerHtmlUrl: el.owner.web_url,
+      ownerName: el.namespace.path,
+      readmeHtml: null,
+      repoHtmlUrl: el.web_url,
+      repoName: el.path,
+      scrapeRecipe: 'gitlab'
+    })
+  }))
+}

--- a/tests/fixtures/gitlab/api/v4/projects/2001/languages/index.json
+++ b/tests/fixtures/gitlab/api/v4/projects/2001/languages/index.json
@@ -1,0 +1,6 @@
+{
+  "JavaScript": 46.11,
+  "Mathematica": 33.39,
+  "C#": 12.06,
+  "ShaderLab": 8.44
+}

--- a/tests/fixtures/gitlab/api/v4/projects/2001/merge_requests/index.json
+++ b/tests/fixtures/gitlab/api/v4/projects/2001/merge_requests/index.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": 21694330,
+    "iid": 1,
+    "project_id": 2001,
+    "title": "WIP: Develop",
+    "description": "Just testing around",
+    "state": "opened",
+    "created_at": "2019-01-02T19:27:49.449Z",
+    "updated_at": "2019-01-02T19:27:49.449Z",
+    "merged_by": null,
+    "merged_at": null,
+    "closed_by": null,
+    "closed_at": null,
+    "target_branch": "master",
+    "source_branch": "develop",
+    "upvotes": 0,
+    "downvotes": 0,
+    "author": {
+      "id": 2217,
+      "name": "Jon Lauridsen",
+      "username": "gaggle",
+      "state": "active",
+      "avatar_url": "https://secure.gravatar.com/avatar/d92ea202a1c0ed94d48f3a1a56eb613c?s=80&d=identicon",
+      "web_url": "https://gitlab.com/gaggle"
+    },
+    "assignee": null,
+    "source_project_id": 2001,
+    "target_project_id": 2001,
+    "labels": [],
+    "work_in_progress": true,
+    "milestone": null,
+    "merge_when_pipeline_succeeds": false,
+    "merge_status": "cannot_be_merged",
+    "sha": "cbfd74c9c0bd03c917ec321929b1fba10b984167",
+    "merge_commit_sha": null,
+    "user_notes_count": 0,
+    "discussion_locked": null,
+    "should_remove_source_branch": null,
+    "force_remove_source_branch": false,
+    "web_url": "https://gitlab.com/gaggle/playground/merge_requests/1",
+    "time_stats": {
+      "time_estimate": 0,
+      "total_time_spent": 0,
+      "human_time_estimate": null,
+      "human_total_time_spent": null
+    },
+    "squash": false,
+    "approvals_before_merge": null
+  }
+]

--- a/tests/fixtures/gitlab/api/v4/projects/owned=true.json
+++ b/tests/fixtures/gitlab/api/v4/projects/owned=true.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": 2001,
+    "description": "This is a description",
+    "name": "playground",
+    "name_with_namespace": "Jon Lauridsen / playground",
+    "path": "playground",
+    "path_with_namespace": "gaggle/playground",
+    "created_at": "2013-02-02T01:04:24.000Z",
+    "default_branch": "master",
+    "tag_list": [],
+    "ssh_url_to_repo": "git@gitlab.com:gaggle/playground.git",
+    "http_url_to_repo": "https://gitlab.com/gaggle/playground.git",
+    "web_url": "https://gitlab.com/gaggle/playground",
+    "readme_url": "https://gitlab.com/gaggle/playground/blob/master/README.md",
+    "avatar_url": null,
+    "star_count": 0,
+    "forks_count": 0,
+    "last_activity_at": "2019-01-02T19:27:49.562Z",
+    "namespace": {
+      "id": 2021,
+      "name": "gaggle",
+      "path": "gaggle",
+      "kind": "user",
+      "full_path": "gaggle",
+      "parent_id": null
+    },
+    "_links": {
+      "self": "https://gitlab.com/api/v4/projects/2001",
+      "issues": "https://gitlab.com/api/v4/projects/2001/issues",
+      "merge_requests": "https://gitlab.com/api/v4/projects/2001/merge_requests",
+      "repo_branches": "https://gitlab.com/api/v4/projects/2001/repository/branches",
+      "labels": "https://gitlab.com/api/v4/projects/2001/labels",
+      "events": "https://gitlab.com/api/v4/projects/2001/events",
+      "members": "https://gitlab.com/api/v4/projects/2001/members"
+    },
+    "archived": false,
+    "visibility": "private",
+    "owner": {
+      "id": 2217,
+      "name": "Jon Lauridsen",
+      "username": "gaggle",
+      "state": "active",
+      "avatar_url": "https://secure.gravatar.com/avatar/d92ea202a1c0ed94d48f3a1a56eb613c?s=80&d=identicon",
+      "web_url": "https://gitlab.com/gaggle"
+    },
+    "resolve_outdated_diff_discussions": null,
+    "container_registry_enabled": null,
+    "issues_enabled": true,
+    "merge_requests_enabled": true,
+    "wiki_enabled": true,
+    "jobs_enabled": true,
+    "snippets_enabled": false,
+    "shared_runners_enabled": true,
+    "lfs_enabled": true,
+    "creator_id": 2217,
+    "import_status": "none",
+    "open_issues_count": 0,
+    "public_jobs": true,
+    "ci_config_path": null,
+    "shared_with_groups": [],
+    "only_allow_merge_if_pipeline_succeeds": false,
+    "request_access_enabled": true,
+    "only_allow_merge_if_all_discussions_are_resolved": null,
+    "printing_merge_request_link_enabled": true,
+    "merge_method": "merge",
+    "permissions": {
+      "project_access": {
+        "access_level": 40,
+        "notification_level": 3
+      },
+      "group_access": null
+    },
+    "mirror": false,
+    "external_authorization_classification_label": ""
+  }
+]

--- a/tests/lib/fileutils.test.js
+++ b/tests/lib/fileutils.test.js
@@ -48,6 +48,6 @@ describe('getRecipe', () => {
 
 describe('getRecipeNames', () => {
   it('should return files in recipes folder', () => {
-    expect(fileutils.getRecipeNames()).toEqual(['github'])
+    expect(fileutils.getRecipeNames()).toEqual(['github', 'gitlab'])
   })
 })

--- a/tests/recipes/gitlab.test.js
+++ b/tests/recipes/gitlab.test.js
@@ -1,0 +1,158 @@
+/* global jest, describe, it, beforeEach, afterEach, expect */
+const lo = require('lodash')
+
+const objContaining = expect.objectContaining
+
+const Container = require('../../lib/cached-requester')
+const errors = require('../../lib/errors')
+const recipe = require('../../recipes/gitlab')
+
+const languagesData = require('../fixtures/gitlab/api/v4/projects/2001/languages')
+const mergeRequestsData = require('../fixtures/gitlab/api/v4/projects/2001/merge_requests')
+const projectsData = require('../fixtures/gitlab/api/v4/projects/owned=true')
+
+jest.mock('../../lib/cached-requester', () => jest.fn().mockImplementation(() => ({
+  addStaticFile: jest.fn(),
+  safeRequest: jest.fn().mockResolvedValue(Buffer.from('')),
+  setRepoData: jest.fn()
+})))
+
+describe('initialize', () => {
+  const oldEnv = process.env
+
+  beforeEach(() => { process.env = { ...oldEnv } })
+
+  afterEach(() => { process.env = oldEnv })
+
+  it('should raise error w. missing env. variable', async () => {
+    await expect(recipe.initialize()).rejects.toBeInstanceOf(errors.InitializeError)
+  })
+
+  it('should pass w. variables specified', async () => {
+    process.env.GL_TOKEN = 'token'
+    await expect(recipe.initialize()).resolves.toBe(undefined)
+  })
+})
+
+describe('scrape', () => {
+  const oldEnv = process.env
+  let container
+
+  beforeEach(() => {
+    container = new Container()
+    container.mockData = {}
+    container.setRepoData.mockImplementation((key, d) => {
+      if (container.mockData[key] === undefined) container.mockData[key] = {}
+      lo.merge(container.mockData[key], d)
+    })
+
+    process.env = { ...oldEnv }
+  })
+
+  afterEach(() => { process.env = oldEnv })
+
+  const expectMockDataToEqual = ideal => expect(container.mockData['gaggle/playground']).toEqual(ideal)
+
+  it('should specify scrape recipe', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({ scrapeRecipe: 'gitlab' }))
+  })
+
+  it('should scrape unique id', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({ id: 'gaggle/playground' }))
+  })
+
+  it('should scrape basic repo information', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({
+      description: 'This is a description',
+      fullName: 'Jon Lauridsen / playground',
+      ownerHtmlUrl: 'https://gitlab.com/gaggle',
+      ownerName: 'gaggle',
+      repoHtmlUrl: 'https://gitlab.com/gaggle/playground',
+      repoName: 'playground'
+    }))
+  })
+
+  it('should scrape issues', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({
+      openIssues: 0,
+      openIssuesHtmlUrl: 'https://gitlab.com/gaggle/playground/issues'
+    }))
+  })
+
+  it('should scrape merge requests', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({
+      openPullrequests: 1,
+      openPullrequestsHtmlUrl: 'https://gitlab.com/gaggle/playground/merge_requests'
+    }))
+  })
+  it('should scrape language', async () => {
+    mockRequests(container.safeRequest)
+
+    await recipe.scrape(container)
+
+    expectMockDataToEqual(objContaining({
+      language: 'JavaScript'
+    }))
+  })
+
+  describe('debug filtering', () => {
+    it('should allow .* to find all repos', async () => {
+      process.env.DEBUG_FILTER_REPO = '.*'
+      mockRequests(container.safeRequest)
+
+      await recipe.scrape(container)
+
+      expect(Object.keys(container.mockData).length).toEqual(1)
+    })
+
+    it('should allow filtering away all repos', async () => {
+      process.env.DEBUG_FILTER_REPO = 'FOOBAR'
+      mockRequests(container.safeRequest)
+
+      await recipe.scrape(container)
+
+      expect(Object.keys(container.mockData).length).toEqual(0)
+    })
+  })
+})
+
+const bufferify = (data) => Buffer.from(JSON.stringify(data))
+
+const mockRequests = (mockFn) => {
+  return mockFn
+    .mockImplementation((cacheKey, payload) => {
+      if (cacheKey === 'gl_projects') {
+        return bufferify(projectsData)
+      }
+
+      if (cacheKey.includes('gl_merge_request')) {
+        return bufferify(mergeRequestsData)
+      }
+
+      if (cacheKey.includes('gl_languages')) {
+        return bufferify(languagesData)
+      }
+
+      throw new Error(`Unknown request for ${payload.url}`)
+    })
+}


### PR DESCRIPTION
This should get the train going… the API offers no easy way to get the HTML of the README.md file so this doesn't scrape for badges. But hey the other information is there.

A later PR can try to tackle that README business.